### PR TITLE
Upgrade Django

### DIFF
--- a/dle/requirements.txt
+++ b/dle/requirements.txt
@@ -7,7 +7,7 @@ charset-normalizer==2.0.12
 click==8.0.4
 cycler==0.11.0
 diff-match-patch==20200713
-Django==4.0.2
+Django==4.0.10
 django-environ==0.9.0
 djangorestframework==3.14.0
 elasticsearch-django==8.2

--- a/dle/run-tests.sh
+++ b/dle/run-tests.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-python3 dle/manage.py test --noinput
+python3 -Wa dle/manage.py test --noinput


### PR DESCRIPTION
Show deprecation warnings in tests if any are raised.

Going 4.0.2 -> 4.0.10 -> 4.1.8 -> 4.2